### PR TITLE
TOOLS-2525 Everything needs to stop cloning with git:// URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"extsprintf": "~1.0.3",
 		"jsprim": "~0.5.1",
-		"joyent-schemas": "git://github.com/joyent/schemas.git#master"
+		"joyent-schemas": "https://github.com/joyent/schemas.git#master"
 	}
 }


### PR DESCRIPTION
This is required to get eng.tritondatacenter up.